### PR TITLE
非同期通信の実装#1

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,5 +12,4 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,6 +1,65 @@
 $(function(){
+  function buildHTML(message){
+    if ( message.image ) {
+      var html =
+       `<div class="message" data-message-id=${message.id}>
+          <div class="message-upper">
+            <div class="message-upper__name">
+              ${message.user_name}
+            </div>
+            <div class="message-upper__date">
+              ${message.created_at}
+            </div>
+          </div>
+          <div class="message-under">
+            <p class="message-under__text">
+              ${message.content}
+            </p>
+          </div>
+          <img src=${message.image} >
+        </div>`
+      return html;
+    } else {
+      var html =
+       `<div class="message" data-message-id=${message.id}>
+          <div class="message-upper">
+            <div class="message-upper__name">
+              ${message.user_name}
+            </div>
+            <div class="message-upper__date">
+              ${message.created_at}
+            </div>
+          </div>
+          <div class="message-under">
+            <p class="message-under__text">
+              ${message.content}
+            </p>
+          </div>
+        </div>`
+      return html;
+    };
+  }
   $('#new_message').on('submit',function(e){
-    console.log('hoge');
-    e.preventDefault()
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr('action');
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function(data){
+      var html = buildHTML(data);
+      $('.messages').append(html);
+      $('form')[0].reset();
+      $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight})
+      $('.submit-btn').prop('disabled', false);
+    })
+    .fail(function() {
+      alert("メッセージ送信に失敗しました");
   });
+  })
 });

--- a/app/assets/stylesheets/_messages.scss
+++ b/app/assets/stylesheets/_messages.scss
@@ -116,20 +116,20 @@
       &-upper{
         display: flex;
         margin-bottom: 12px;
-        &-name{
+        &__name{
           font-size: 16px;
           color: #333333;
           font-weight: bold;
         }
-        &-date{
+        &__date{
           font-size: 12px;
           color: #999999;
           margin-left: 10px;
         }
       }
-      &__under{
+      &-under{
         margin-bottom: 46px;
-        &-text{
+        &__text{
           font-size: 14px;
           color: #434A54;
         }

--- a/app/assets/stylesheets/_messages.scss
+++ b/app/assets/stylesheets/_messages.scss
@@ -111,8 +111,8 @@
   .messages{
     height: calc(100vh - 190px);
     padding: 46px 40px;
+    overflow: scroll;
     .message{
-      padding-bottom: 40px;
       &-upper{
         display: flex;
         margin-bottom: 12px;

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,9 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,11 +1,11 @@
-.messages
-  .messages-message__upper
-    %p.messages-message__upper-name 
+.message
+  .message-upper
+    %p.message-upper__name 
       = message.user.name
-    %p.messages-message__upper-date 
+    %p.message-upper__date 
       = message.created_at.strftime ("%Y年%m月%d日 %H時%M分")
-  .messages-message__under
+  .message-under
     - if message.body.present?
-      %p.messages-messages__under-text
+      %p.messages-under__text
       = message.body
     = image_tag message.image.url, class: 'lower-message__image' if message.image.present?

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.user_name @message.user.name
+json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.content @message.body
+json.image @message.image_url

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,7 @@ Bundler.require(*Rails.groups)
 
 module ChatSpace
   class Application < Rails::Application
+    config.time_zone = 'Tokyo'
     config.generators do |g|
       g.stylesheets false
       g.javascripts false


### PR DESCRIPTION
# What
1. chat-spaceの投稿機能において、リロードされることなく、投稿できるような実装をした。
2. 常に新しい投稿を表示させるよう、jQeryのanimationメソッドを使った。
3. テキストのみ/画像のみ/画像とテキスト、それぞれでエラーが出ずに投稿ができるようにした。
4. 連続での投稿が可能を可能にした。
5. 日時表記をTokyoの日時で合わせている。
6. SENDボタンを連打したら適切なアラートが表示される。
# Why
メッセージを送信するたびに送信画面にリダイレクトしているため、ビューが毎回再描画されてしまう為、処理速度の低下に繋がるから。

<a href="https://gyazo.com/d19e4a7a5de50320242121d90dd44dfa"><img src="https://i.gyazo.com/d19e4a7a5de50320242121d90dd44dfa.gif" alt="Image from Gyazo" width="1000"/></a>
